### PR TITLE
feat: Add order management endpoints

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,3 +17,7 @@ dependencies = [
 tortoise_orm = "backend.main.TORTOISE_ORM_CONFIG"
 location = "./migrations"
 src_folder = "../"
+
+[tool.uv.dev-dependencies]
+pytest = "*"
+pytest-asyncio = "*"

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -42,6 +42,16 @@ class PaginatedInventoryResponse(BaseModel):
         from_attributes = True
 
 
+# --- Schemas for Order Updates (PATCH requests) ---
+
+class OrderShipRequestSchema(BaseModel):
+    tracking_number: Optional[str] = Field(None, description="Tracking number for the shipment")
+    shipping_provider: Optional[str] = Field(None, description="Shipping provider for the shipment")
+
+class OrderCancelRequestSchema(BaseModel):
+    reason: Optional[str] = Field(None, description="Reason for cancelling the order")
+
+
 # --- Order Schemas ---
 
 class OrderItemBase(BaseModel):

--- a/backend/tests/test_orders.py
+++ b/backend/tests/test_orders.py
@@ -1,10 +1,10 @@
 import pytest
-from fastapi.testclient import TestClient
+from httpx import AsyncClient # Use AsyncClient for async tests
 from backend.main import app # Or import client fixture from conftest
 
 # Assuming models and schemas might be needed for direct assertions or setup
-from backend.models import Order, OrderItem, OrderEvent, InventoryItem
-from backend.schemas import OrderPublicSchema, OrderItemPublicSchema
+from backend.models import Order, OrderItem, OrderEvent, InventoryItem, generate_ksuid
+from backend.schemas import OrderPublicSchema, OrderItemPublicSchema, OrderShipRequestSchema, OrderCancelRequestSchema
 
 # Use anyio_backend fixture from conftest if not already picked up
 pytestmark = pytest.mark.anyio
@@ -53,7 +53,26 @@ async def test_create_order_success(client: TestClient):
     current_year = str(datetime.now().year)
     assert data["order_id"].startswith(current_year)
 
-async def test_create_order_no_items(client: TestClient):
+async def create_order_for_test(client: AsyncClient, inventory_item_public_id: str, contact_name: str = "Test Order User") -> OrderPublicSchema:
+    """Helper function to create an order for testing purposes."""
+    order_payload = {
+        "contact_name": contact_name,
+        "contact_email": "testorder@example.com",
+        "delivery_address": "123 Test Order St",
+        "items": [
+            {
+                "product_public_id": inventory_item_public_id,
+                "quantity": 1,
+                "price_at_purchase": 25.00
+            }
+        ]
+    }
+    response = await client.post("/api/v1/orders/", json=order_payload)
+    assert response.status_code == 201
+    return OrderPublicSchema(**response.json())
+
+
+async def test_create_order_no_items(client: AsyncClient):
     order_payload = {
         "contact_name": "Test User No Items",
         "contact_email": "testnoitems@example.com",
@@ -63,7 +82,7 @@ async def test_create_order_no_items(client: TestClient):
     response = await client.post("/api/v1/orders/", json=order_payload)
     assert response.status_code == 422 # FastAPI's validation error for Pydantic min_length
 
-async def test_get_order_success(client: TestClient):
+async def test_get_order_success(client: AsyncClient):
     # 1. Create an order first
     inventory_item = await setup_test_inventory_item()
     order_payload = {
@@ -88,12 +107,183 @@ async def test_get_order_success(client: TestClient):
     assert retrieved_order_data["items"][0]["product_public_id"] == inventory_item.public_id
     assert len(retrieved_order_data["events"]) > 0 # Should have at least 'order_placed'
 
-async def test_get_order_not_found(client: TestClient):
-    non_existent_ksuid = "000000000000000000000000000" # A valid KSUID format but likely non-existent
+async def test_get_order_not_found(client: AsyncClient):
+    non_existent_ksuid = generate_ksuid() # Generate a valid KSUID that won't exist
     response = await client.get(f"/api/v1/orders/{non_existent_ksuid}")
     assert response.status_code == 404
+
+# --- Tests for PATCH /orders/{order_public_id}/ship ---
+
+async def test_ship_order_success_no_details(client: AsyncClient):
+    inventory_item = await setup_test_inventory_item()
+    order = await create_order_for_test(client, inventory_item.public_id, "Ship Order No Details User")
+
+    response = await client.patch(f"/api/v1/orders/{order.public_id}/ship")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["public_id"] == order.public_id
+    assert data["status"] == "shipped"
+
+    # Verify OrderEvent
+    updated_order = await Order.get(public_id=order.public_id).prefetch_related("events")
+    assert updated_order.status == "shipped"
+    shipped_event = next((e for e in updated_order.events if e.event_type == "order_shipped"), None)
+    assert shipped_event is not None
+    assert shipped_event.data == {"message": "Order marked as shipped."}
+
+async def test_ship_order_success_with_details(client: AsyncClient):
+    inventory_item = await setup_test_inventory_item()
+    order = await create_order_for_test(client, inventory_item.public_id, "Ship Order With Details User")
+
+    ship_payload = {
+        "tracking_number": "TRK12345",
+        "shipping_provider": "FastShip"
+    }
+    response = await client.patch(f"/api/v1/orders/{order.public_id}/ship", json=ship_payload)
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["status"] == "shipped"
+    assert data["public_id"] == order.public_id
+
+    # Verify OrderEvent directly from DB to be sure
+    updated_order_db = await Order.get(public_id=order.public_id).prefetch_related("events")
+    assert updated_order_db.status == "shipped"
+    shipped_event = next((e for e in updated_order_db.events if e.event_type == "order_shipped"), None)
+    assert shipped_event is not None
+    assert shipped_event.data["tracking_number"] == "TRK12345"
+    assert shipped_event.data["shipping_provider"] == "FastShip"
+
+async def test_ship_order_not_found(client: AsyncClient):
+    non_existent_ksuid = generate_ksuid()
+    response = await client.patch(f"/api/v1/orders/{non_existent_ksuid}/ship")
+    assert response.status_code == 404
+
+async def test_ship_order_already_shipped(client: AsyncClient):
+    inventory_item = await setup_test_inventory_item()
+    order = await create_order_for_test(client, inventory_item.public_id, "Already Shipped User")
+
+    # Ship it once
+    await client.patch(f"/api/v1/orders/{order.public_id}/ship")
+
+    # Try to ship again
+    response = await client.patch(f"/api/v1/orders/{order.public_id}/ship")
+    assert response.status_code == 400
+    assert "already shipped" in response.json()["detail"].lower()
+
+async def test_ship_order_cancelled(client: AsyncClient):
+    inventory_item = await setup_test_inventory_item()
+    order = await create_order_for_test(client, inventory_item.public_id, "Ship Cancelled User")
+
+    # Cancel it first
+    await client.patch(f"/api/v1/orders/{order.public_id}/cancel", json={"reason": "Test cancellation"})
+
+    # Try to ship
+    response = await client.patch(f"/api/v1/orders/{order.public_id}/ship")
+    assert response.status_code == 400
+    assert "cannot ship a cancelled order" in response.json()["detail"].lower()
+
+# --- Tests for PATCH /orders/{order_public_id}/cancel ---
+
+async def test_cancel_order_success_no_reason(client: AsyncClient):
+    inventory_item = await setup_test_inventory_item()
+    order = await create_order_for_test(client, inventory_item.public_id, "Cancel No Reason User")
+
+    response = await client.patch(f"/api/v1/orders/{order.public_id}/cancel")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["public_id"] == order.public_id
+    assert data["status"] == "cancelled"
+
+    updated_order = await Order.get(public_id=order.public_id).prefetch_related("events")
+    assert updated_order.status == "cancelled"
+    cancelled_event = next((e for e in updated_order.events if e.event_type == "order_cancelled"), None)
+    assert cancelled_event is not None
+    assert cancelled_event.data == {"message": "Order marked as cancelled."}
+
+async def test_cancel_order_success_with_reason(client: AsyncClient):
+    inventory_item = await setup_test_inventory_item()
+    order = await create_order_for_test(client, inventory_item.public_id, "Cancel With Reason User")
+
+    cancel_payload = {"reason": "Customer changed mind"}
+    response = await client.patch(f"/api/v1/orders/{order.public_id}/cancel", json=cancel_payload)
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["status"] == "cancelled"
+    assert data["public_id"] == order.public_id
+
+    updated_order_db = await Order.get(public_id=order.public_id).prefetch_related("events")
+    assert updated_order_db.status == "cancelled"
+    cancelled_event = next((e for e in updated_order_db.events if e.event_type == "order_cancelled"), None)
+    assert cancelled_event is not None
+    assert cancelled_event.data["reason"] == "Customer changed mind"
+
+async def test_cancel_order_not_found(client: AsyncClient):
+    non_existent_ksuid = generate_ksuid()
+    response = await client.patch(f"/api/v1/orders/{non_existent_ksuid}/cancel")
+    assert response.status_code == 404
+
+async def test_cancel_order_already_cancelled(client: AsyncClient):
+    inventory_item = await setup_test_inventory_item()
+    order = await create_order_for_test(client, inventory_item.public_id, "Already Cancelled User")
+
+    # Cancel it once
+    await client.patch(f"/api/v1/orders/{order.public_id}/cancel")
+
+    # Try to cancel again
+    response = await client.patch(f"/api/v1/orders/{order.public_id}/cancel")
+    assert response.status_code == 400
+    assert "already cancelled" in response.json()["detail"].lower()
+
+async def test_cancel_order_shipped_allowed_with_reason(client: AsyncClient):
+    # Based on current router logic: shipped orders can be cancelled if a reason is provided.
+    inventory_item = await setup_test_inventory_item()
+    order = await create_order_for_test(client, inventory_item.public_id, "Cancel Shipped User")
+
+    # Ship it first
+    await client.patch(f"/api/v1/orders/{order.public_id}/ship", json={"tracking_number": "TRKSHIPFIRST"})
+
+    # Try to cancel WITH a reason
+    cancel_payload = {"reason": "Customer requested cancellation after shipping"}
+    response = await client.patch(f"/api/v1/orders/{order.public_id}/cancel", json=cancel_payload)
+    assert response.status_code == 200 # Current router logic allows this
+    data = response.json()
+    assert data["status"] == "cancelled"
+
+    updated_order_db = await Order.get(public_id=order.public_id).prefetch_related("events")
+    assert updated_order_db.status == "cancelled"
+    cancelled_event = next((e for e in updated_order_db.events if e.event_type == "order_cancelled"), None)
+    assert cancelled_event is not None
+    assert cancelled_event.data["reason"] == "Customer requested cancellation after shipping"
+
+async def test_cancel_order_shipped_allowed_no_reason(client: AsyncClient):
+    # Based on current router logic: shipped orders can be cancelled even without a reason.
+    inventory_item = await setup_test_inventory_item()
+    order = await create_order_for_test(client, inventory_item.public_id, "Cancel Shipped No Reason User")
+
+    # Ship it first
+    await client.patch(f"/api/v1/orders/{order.public_id}/ship", json={"tracking_number": "TRKSHIPFIRSTNOREASON"})
+
+    # Try to cancel WITHOUT a reason
+    response = await client.patch(f"/api/v1/orders/{order.public_id}/cancel")
+    assert response.status_code == 200 # Current router logic allows this
+    data = response.json()
+    assert data["status"] == "cancelled"
+
+    updated_order_db = await Order.get(public_id=order.public_id).prefetch_related("events")
+    assert updated_order_db.status == "cancelled"
+    cancelled_event = next((e for e in updated_order_db.events if e.event_type == "order_cancelled"), None)
+    assert cancelled_event is not None
+    assert cancelled_event.data == {"message": "Order marked as cancelled."}
+
 
 # To run these tests:
 # Ensure pytest and pytest-asyncio are installed.
 # From the project root (parent of 'backend'), run:
-# PYTHONPATH=. pytest backend/tests
+# PYTHONPATH=.:$PYTHONPATH pytest backend/tests
+# or if using the app dir directly (less common for multi-component projects):
+# pytest (from within backend dir, if PYTHONPATH is set up for backend.models etc.)
+# Best practice is usually from project root with PYTHONPATH=.


### PR DESCRIPTION
This commit introduces new functionality for managing orders:

-   **Ship Order:** A PATCH endpoint `/api/v1/orders/{order_public_id}/ship` allows marking an order as shipped. It updates the order status and records an "order_shipped" event with optional tracking information.
-   **Cancel Order:** A PATCH endpoint `/api/v1/orders/{order_public_id}/cancel` allows canceling an order. It updates the order status and records an "order_cancelled" event with an optional reason.

New Pydantic schemas `OrderShipRequestSchema` and `OrderCancelRequestSchema` have been added for request body validation.

Additionally, `pytest` and `pytest-asyncio` have been installed as development dependencies using `uv` to facilitate testing. Comprehensive unit tests for the new endpoints have been added to `backend/tests/test_orders.py`.