### PR TITLE
Refactor: Separate logging configuration into its own module

### DIFF
--- a/src/app/core/logging_config.py
+++ b/src/app/core/logging_config.py
@@ -1,0 +1,66 @@
+import logging
+import sys
+
+class NamespaceFilter(logging.Filter):
+    def __init__(self, allowed_namespaces=None):
+        super().__init__()
+        self.allowed_namespaces = allowed_namespaces if allowed_namespaces is not None else []
+
+    def filter(self, record):
+        if not self.allowed_namespaces:
+            return True # If no namespaces are specified, allow all records
+        # Allow record if its name starts with any of the allowed namespaces
+        return any(record.name.startswith(ns) for ns in self.allowed_namespaces)
+
+log_formatter = logging.Formatter(
+    fmt="%(asctime)s - %(name)s:%(lineno)d - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+app_logger = logging.getLogger("app")
+app_logger.setLevel(logging.INFO)
+
+console_handler = logging.StreamHandler(sys.stdout)
+console_handler.setFormatter(log_formatter)
+
+# --- Namespace-based Filter (Optional) ---
+# To only allow logs from specific top-level namespaces.
+# For example, to only see logs from "app.features" and "app.main":
+#
+# allowed_log_namespaces = ["app.features", "app.main"]
+# namespace_filter = NamespaceFilter(allowed_log_namespaces)
+# console_handler.addFilter(namespace_filter)
+#
+# If `allowed_log_namespaces` is empty or None, the filter will allow all logs.
+# This can be driven by environment variables for more dynamic control.
+# For now, it's commented out to not break existing logging behavior
+# until explicitly configured by the user.
+app_logger.addHandler(console_handler)
+
+# --- Namespace-specific logging level configuration examples ---
+# To set a different level for a specific part of the application:
+# For example, to see DEBUG messages from the 'orders' feature:
+logging.getLogger("app.features.orders").setLevel(logging.DEBUG)
+
+# And perhaps less verbose logging for another part:
+# logging.getLogger("app.features.inventory").setLevel(logging.WARNING)
+
+# Note: For these configurations to take effect, modules must use
+# logging.getLogger(__name__) which will create loggers like
+# "app.features.orders.router" or "app.services.some_service".
+# These child loggers will inherit levels from their parents (e.g., "app.features.orders")
+# or the application's root logger ("app") if not specifically set.
+
+
+
+# sh = logging.StreamHandler(sys.stdout)
+# sh.setLevel(logging.DEBUG)
+# sh.setFormatter(fmt)
+# # will print debug sql
+# logger_db_client = logging.getLogger("tortoise.db_client")
+# logger_db_client.setLevel(logging.DEBUG)
+# # logger_db_client.addHandler(sh)
+#
+# logger_tortoise = logging.getLogger("tortoise")
+# logger_tortoise.setLevel(logging.DEBUG)
+# # logger_tortoise.addHandler(sh)

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -7,6 +6,7 @@ from fastapi import FastAPI, Request
 from tortoise import generate_config
 from tortoise.contrib.fastapi import register_tortoise, tortoise_exception_handlers
 
+from .core.logging_config import app_logger # Ensure app_logger is imported to initialize logging
 
 # Assuming your routers and models are structured to be imported like this.
 # This might require tiny-sales/backend to be in PYTHONPATH or specific run configurations.
@@ -20,75 +20,7 @@ from .features.reports.router import router as reports_router
 # from routers import auth as auth_router # Import the new auth router
 # from routers import reports as reports_router # New import
 
-
-# Configure basic logging
-# For production, consider a more robust logging setup (e.g., structured logging, log rotation)
-
-class NamespaceFilter(logging.Filter):
-    def __init__(self, allowed_namespaces=None):
-        super().__init__()
-        self.allowed_namespaces = allowed_namespaces if allowed_namespaces is not None else []
-
-    def filter(self, record):
-        if not self.allowed_namespaces:
-            return True # If no namespaces are specified, allow all records
-        # Allow record if its name starts with any of the allowed namespaces
-        return any(record.name.startswith(ns) for ns in self.allowed_namespaces)
-
-log_formatter = logging.Formatter(
-    fmt="%(asctime)s - %(name)s:%(lineno)d - %(levelname)s - %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
-
-app_logger = logging.getLogger("app")
-app_logger.setLevel(logging.INFO)
-
-console_handler = logging.StreamHandler(sys.stdout)
-console_handler.setFormatter(log_formatter)
-
-# --- Namespace-based Filter (Optional) ---
-# To only allow logs from specific top-level namespaces.
-# For example, to only see logs from "app.features" and "app.main":
-#
-# allowed_log_namespaces = ["app.features", "app.main"]
-# namespace_filter = NamespaceFilter(allowed_log_namespaces)
-# console_handler.addFilter(namespace_filter)
-#
-# If `allowed_log_namespaces` is empty or None, the filter will allow all logs.
-# This can be driven by environment variables for more dynamic control.
-# For now, it's commented out to not break existing logging behavior
-# until explicitly configured by the user.
-app_logger.addHandler(console_handler)
-
-logger = logging.getLogger("app.main")
-
-# --- Namespace-specific logging level configuration examples ---
-# To set a different level for a specific part of the application:
-# For example, to see DEBUG messages from the 'orders' feature:
-logging.getLogger("app.features.orders").setLevel(logging.DEBUG)
-
-# And perhaps less verbose logging for another part:
-# logging.getLogger("app.features.inventory").setLevel(logging.WARNING)
-
-# Note: For these configurations to take effect, modules must use
-# logging.getLogger(__name__) which will create loggers like
-# "app.features.orders.router" or "app.services.some_service".
-# These child loggers will inherit levels from their parents (e.g., "app.features.orders")
-# or the application's root logger ("app") if not specifically set.
-
-
-
-# sh = logging.StreamHandler(sys.stdout)
-# sh.setLevel(logging.DEBUG)
-# sh.setFormatter(fmt)
-# # will print debug sql
-# logger_db_client = logging.getLogger("tortoise.db_client")
-# logger_db_client.setLevel(logging.DEBUG)
-# # logger_db_client.addHandler(sh)
-#
-# logger_tortoise = logging.getLogger("tortoise")
-# logger_tortoise.setLevel(logging.DEBUG)
-# # logger_tortoise.addHandler(sh)
+logger = logging.getLogger("app.main") # This logger will inherit from 'app'
 
 # TORTOISE_ORM_CONFIG
 # Ensure the 'models' path is correct for your setup.


### PR DESCRIPTION
I've moved the logging setup from `src/app/main.py` to a new dedicated module `src/app/core/logging_config.py`.

This change helps to declutter `main.py` and centralizes the logging configuration, making it easier for you to manage and modify in the future.

The `main.py` file now imports the necessary logger (`app_logger` for its side effect of configuring the root 'app' logger) from the new module and defines its own `app.main` logger which inherits the established configuration.